### PR TITLE
Many Updates and added Tabstops instead of spaces

### DIFF
--- a/db.net.freifunk.lauenburg
+++ b/db.net.freifunk.lauenburg
@@ -11,12 +11,15 @@ $ORIGIN lauenburg.freifunk.net.
                             900 )       ; Negative Cache TTL
 
 ;; Authorative Nameserver
-				NS	zemvol.de.
 
-;;zemvol.de.	IN	A 88.198.243.187
+				NS	ns0.wollgast-it.de.
+				NS	ns1.wollgast-it.de
 
-lauenburg.freifunk.net.                IN      A       176.9.83.62
-www                IN      A       176.9.83.62
+ns0.wollgast-it.de.	IN	A	176.9.65.215
+ns1.wollgast-it.de.	IN	A	176.9.83.62
+
+lauenburg.freifunk.net.	IN	A	176.9.83.62
+www			IN	A	176.9.83.62
 
 ;; Update
 firmware                IN      A       10.144.0.112
@@ -27,8 +30,8 @@ ntp                     IN      A       10.144.0.3
                         IN      AAAA    fddf:0bf7:80::a38:3
 
 ;; FF Map
-map                     IN      A       10.144.128.1
-                        IN      AAAA    fddf:0bf7:80::128:1
+map			IN	A	10.144.128.1
+			IN	AAAA	fddf:0bf7:80::128:1
 
 ;; Knoten
 knoten                  IN      AAAA    fddf:0bf7:80::a38:1
@@ -41,19 +44,21 @@ router        CNAME 	knoten
 ;;                        IN      AAAA    fddf:0bf7:80::a38:2
 
 ;;Mail
-mail                      IN      A       88.198.243.188
-                          IN      MX    10 mail.lauenburg.freifunk.net.
+mail			IN	A	176.9.83.61
+			IN	MX	10 mail.lauenburg.freifunk.net.
 
 ;; Gateways
-;;barnitz                 IN      A       37.120.163.174
-;;beste                   IN      A       5.9.111.91
-bille                   IN      A       88.198.243.190
-trave                   IN      A       88.198.243.186
+;;barnitz		IN	A	37.120.163.174
+;;beste			IN	A	5.9.111.91
+bille                   IN      A	88.198.243.190
+trave                   IN      A	88.198.243.186
 hopfenbach		IN	A	176.9.83.62
+viehbach		IN	A       176.9.202.73
+
 
 ;; all other
-;;beispiel                   IN      A       10.144.1.3
+;;beispiel		IN	A	10.144.1.3
 
 ;; Eigene bzw Individuelle Dienste
 $ORIGIN mein.lauenburg.freifunk.net.
-;;beispiel                IN      A       10.144.1.3
+;;beispiel		IN	A	10.144.1.3

--- a/db.net.freifunk.lauenburg
+++ b/db.net.freifunk.lauenburg
@@ -4,7 +4,7 @@
 $TTL    900
 $ORIGIN lauenburg.freifunk.net.
 @       IN      SOA     lauenburg.freifunk.net. info.lauenburg.freifunk.net. (
-                     2016083001         ; Serial
+                     2017120400         ; Serial
                           28800         ; Refresh
                            7200         ; Retry
                          604800         ; Expire


### PR DESCRIPTION
Changes for Mail- and Nameservers, added missing entry for gateway viehbach, reformatting to tabstops instead of spaces in every line that was changed.